### PR TITLE
Potential fix for code scanning alert no. 24: Server-side request forgery

### DIFF
--- a/api/aqicn.ts
+++ b/api/aqicn.ts
@@ -1,12 +1,16 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
+import type { VercelRequest, VercelResponse } from "@vercel/node";
 
 const TOKEN = process.env.AQICN_TOKEN!;
-if (!TOKEN) throw new Error('Missing environment variable AQICN_TOKEN');
+if (!TOKEN) throw new Error("Missing environment variable AQICN_TOKEN");
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
-    const rawLat = Array.isArray(req.query.lat) ? req.query.lat[0] : req.query.lat;
-    const rawLon = Array.isArray(req.query.lon) ? req.query.lon[0] : req.query.lon;
+    const rawLat = Array.isArray(req.query.lat)
+      ? req.query.lat[0]
+      : req.query.lat;
+    const rawLon = Array.isArray(req.query.lon)
+      ? req.query.lon[0]
+      : req.query.lon;
 
     const lat = Number(rawLat);
     const lon = Number(rawLon);
@@ -15,18 +19,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const isValidLon = Number.isFinite(lon) && lon >= -180 && lon <= 180;
 
     if (!isValidLat || !isValidLon) {
-      return res.status(400).json({ error: 'Invalid lat/lon query parameters' });
+      return res
+        .status(400)
+        .json({ error: "Invalid lat/lon query parameters" });
     }
 
     const url = new URL(`https://api.waqi.info/feed/geo:${lat};${lon}/`);
-    url.searchParams.set('token', TOKEN);
+    url.searchParams.set("token", TOKEN);
 
     const apiRes = await fetch(url.toString());
     const data = await apiRes.json();
 
     return res.status(apiRes.status).json(data);
   } catch (err: any) {
-    console.error('AQICN handler error:', err);
+    console.error("AQICN handler error:", err);
     res.status(500).json({ error: err.message });
   }
 }

--- a/api/aqicn.ts
+++ b/api/aqicn.ts
@@ -5,9 +5,23 @@ if (!TOKEN) throw new Error('Missing environment variable AQICN_TOKEN');
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
-    const { lat, lon } = req.query as any;
-    const url = `https://api.waqi.info/feed/geo:${lat};${lon}/?token=${TOKEN}`;
-    const apiRes = await fetch(url);
+    const rawLat = Array.isArray(req.query.lat) ? req.query.lat[0] : req.query.lat;
+    const rawLon = Array.isArray(req.query.lon) ? req.query.lon[0] : req.query.lon;
+
+    const lat = Number(rawLat);
+    const lon = Number(rawLon);
+
+    const isValidLat = Number.isFinite(lat) && lat >= -90 && lat <= 90;
+    const isValidLon = Number.isFinite(lon) && lon >= -180 && lon <= 180;
+
+    if (!isValidLat || !isValidLon) {
+      return res.status(400).json({ error: 'Invalid lat/lon query parameters' });
+    }
+
+    const url = new URL(`https://api.waqi.info/feed/geo:${lat};${lon}/`);
+    url.searchParams.set('token', TOKEN);
+
+    const apiRes = await fetch(url.toString());
     const data = await apiRes.json();
 
     return res.status(apiRes.status).json(data);


### PR DESCRIPTION
Potential fix for [https://github.com/LCSOGthb/AirMerge/security/code-scanning/24](https://github.com/LCSOGthb/AirMerge/security/code-scanning/24)

To fix this without changing intended functionality, validate and normalize `lat`/`lon` before building the outbound URL:

- Accept only single query values (not arrays).
- Parse as finite numbers.
- Enforce coordinate bounds (`lat` in `[-90,90]`, `lon` in `[-180,180]`).
- Build the URL via `URL`/`URLSearchParams` (not raw string concatenation).
- Return `400` for invalid input, instead of attempting fetch.

In `api/aqicn.ts`, update the handler body around lines 8–10 to:
1. Extract raw query params safely.
2. Validate/convert.
3. Construct `URL` with fixed base and safe path segment using numeric values.
4. Keep existing response forwarding behavior.

No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden AQICN API proxy request handling by validating latitude/longitude query parameters before forwarding requests.

Bug Fixes:
- Prevent malformed or out-of-range lat/lon values from being used to construct outbound AQICN API URLs, returning HTTP 400 for invalid input instead of attempting the fetch.

Enhancements:
- Build the AQICN API request URL using the URL API and query parameters rather than raw string concatenation to reduce SSRF risk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the AQICN proxy against SSRF by validating `lat`/`lon` and building the request URL safely. Invalid coordinates now return 400, addressing code scanning alert #24.

- **Bug Fixes**
  - Accept only single `lat`/`lon` values, parse as finite numbers, and enforce bounds (`lat` −90..90, `lon` −180..180).
  - Construct the outbound URL with `URL`/`URLSearchParams` instead of string concatenation.
  - Preserve upstream status/body; no dependency changes.

- **Refactors**
  - Formatted `api/aqicn.ts` with project formatters; no behavior change.

<sup>Written for commit 422186328927977a8b945dac1c8fe758e897978f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LCSOGthb/AirMerge/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

